### PR TITLE
Initialize _pulseCount variable

### DIFF
--- a/src/RadSensBoard.h
+++ b/src/RadSensBoard.h
@@ -17,7 +17,7 @@ private:
     uint8_t _rawData[21] = {0};
     float _radiationLevelDynamic;
     float _radiationLevelStatic;
-    uint32_t _pulseCount;
+    uint32_t _pulseCount = 0;
 
     bool writeRegister(uint8_t registerAddress, uint8_t registerValue);
 


### PR DESCRIPTION
Hi,

I've noticed that `_pulseCount` variable was not initialized to 0. That sometimes leads to the variable, having unpredictable value on startup due to additive assignment (+=) on [this line](https://github.com/vurdalakov/radsensboard/blob/master/src/RadSensBoard.cpp#L61), when `RadSensBoard:readData()` is being called from `RadSenBoard:init()`.

Thank you for your great work on the library!